### PR TITLE
Add unsqueeze calc offline pass to ARM target for Paddlespeech melgan Conversion failed

### DIFF
--- a/lite/core/optimizer/mir/elimination/unsqueeze_calc_offline_pass.cc
+++ b/lite/core/optimizer/mir/elimination/unsqueeze_calc_offline_pass.cc
@@ -108,4 +108,4 @@ void UnsqueezeCalcOfflinePass::RemoveUnsqueezePattern(
 
 REGISTER_MIR_PASS(unsqueeze_calc_offline_pass,
                   paddle::lite::mir::UnsqueezeCalcOfflinePass)
-    .BindTargets({TARGET(kNNAdapter)});
+    .BindTargets({TARGET(kNNAdapter), TARGET(kARM)});


### PR DESCRIPTION
opt工具为ARM target转换Paddle speech melgan模型失败：sparse_conv_detect_pass在转换时会读weight tensor中的数据，读到空指针，这个输入依赖于上一个结点的输出。
解决：引入unsqueeze calc offline pass，预先折叠常量的unsqueeze计算得到卷积的weights。